### PR TITLE
Add initial MMA bot structure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+BOT_TOKEN=your-bot-token-here
+MONGO_URI=mongodb://localhost:27017/mma-bot

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Mmabotdiscord
+# MMA Discord Bot
+
+This project is an inter-server MMA combat bot for Discord, built with **discord.js** and **MongoDB**.
+
+## Features
+
+- Matchmaking with `/fight`
+- User profiles with Elo and statistics using `/profile`
+- Clan system with `/clan`
+- Economy commands like `/balance`
+- Premium and admin commands
+
+## Installation
+
+1. Install Node.js 20.
+2. Copy `.env.example` to `.env` and fill in your bot token and MongoDB URI.
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+4. Start the bot:
+   ```bash
+   node index.js
+   ```
+
+## Notes
+
+The project contains basic implementations as a starting point and does not cover the entire specification. Further development is required to implement full combat mechanics and matchmaking logic.

--- a/commands/admin/admin.js
+++ b/commands/admin/admin.js
@@ -1,0 +1,55 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const User = require('../../src/models/User');
+const Clan = require('../../src/models/Clan');
+
+const ADMIN_ID = '648619791107620887';
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('admin')
+    .setDescription('Administrative commands')
+    .addSubcommand(sc => sc.setName('setelo').setDescription('Set user Elo')
+      .addUserOption(o => o.setName('user').setDescription('User').setRequired(true))
+      .addIntegerOption(o => o.setName('amount').setDescription('Amount').setRequired(true)))
+    .addSubcommand(sc => sc.setName('addmoney').setDescription('Add money')
+      .addUserOption(o => o.setName('user').setDescription('User').setRequired(true))
+      .addIntegerOption(o => o.setName('amount').setDescription('Amount').setRequired(true)))
+    .addSubcommand(sc => sc.setName('removemoney').setDescription('Remove money')
+      .addUserOption(o => o.setName('user').setDescription('User').setRequired(true))
+      .addIntegerOption(o => o.setName('amount').setDescription('Amount').setRequired(true)))
+    .addSubcommand(sc => sc.setName('clan-disband').setDescription('Disband clan')
+      .addStringOption(o => o.setName('name').setDescription('Clan name').setRequired(true))),
+  async execute(interaction) {
+    if (interaction.user.id !== ADMIN_ID) return interaction.reply({ content: 'Unauthorized', ephemeral: true });
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'setelo') {
+      const userOption = interaction.options.getUser('user');
+      const amount = interaction.options.getInteger('amount');
+      const user = await User.findOneAndUpdate({ userId: userOption.id }, { elo: amount }, { upsert: true, new: true });
+      return interaction.reply(`Set Elo of ${userOption.username} to ${amount}.`);
+    }
+
+    if (sub === 'addmoney') {
+      const userOption = interaction.options.getUser('user');
+      const amount = interaction.options.getInteger('amount');
+      const user = await User.findOneAndUpdate({ userId: userOption.id }, { $inc: { money: amount } }, { upsert: true, new: true });
+      return interaction.reply(`Added ${amount} money to ${userOption.username}.`);
+    }
+
+    if (sub === 'removemoney') {
+      const userOption = interaction.options.getUser('user');
+      const amount = interaction.options.getInteger('amount');
+      const user = await User.findOneAndUpdate({ userId: userOption.id }, { $inc: { money: -amount } }, { upsert: true, new: true });
+      return interaction.reply(`Removed ${amount} money from ${userOption.username}.`);
+    }
+
+    if (sub === 'clan-disband') {
+      const name = interaction.options.getString('name');
+      const clan = await Clan.findOneAndDelete({ name });
+      if (!clan) return interaction.reply('Clan not found.');
+      await User.updateMany({ clan: clan._id }, { clan: null });
+      return interaction.reply(`Clan ${name} disbanded.`);
+    }
+  }
+};

--- a/commands/clan/clan.js
+++ b/commands/clan/clan.js
@@ -1,0 +1,63 @@
+const { SlashCommandBuilder } = require('discord.js');
+const User = require('../../src/models/User');
+const Clan = require('../../src/models/Clan');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('clan')
+    .setDescription('Clan management')
+    .addSubcommand(sc => sc.setName('create').setDescription('Create a clan').addStringOption(o => o.setName('name').setDescription('Clan name').setRequired(true)))
+    .addSubcommand(sc => sc.setName('join').setDescription('Join a clan').addStringOption(o => o.setName('name').setDescription('Clan name').setRequired(true)))
+    .addSubcommand(sc => sc.setName('leave').setDescription('Leave your clan'))
+    .addSubcommand(sc => sc.setName('info').setDescription('Info about a clan').addStringOption(o => o.setName('name').setDescription('Clan name').setRequired(true))),
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    if (sub === 'create') {
+      const name = interaction.options.getString('name');
+      const existing = await Clan.findOne({ name });
+      if (existing) return interaction.reply({ content: 'Clan already exists.', ephemeral: true });
+      const clan = await Clan.create({ name });
+      const user = await User.findOneAndUpdate({ userId: interaction.user.id }, { clan: clan._id }, { upsert: true, new: true });
+      clan.members.push(user._id);
+      await clan.save();
+      return interaction.reply(`Clan ${name} created and joined.`);
+    }
+
+    if (sub === 'join') {
+      const name = interaction.options.getString('name');
+      const clan = await Clan.findOne({ name });
+      if (!clan) return interaction.reply({ content: 'Clan not found.', ephemeral: true });
+      const user = await User.findOneAndUpdate({ userId: interaction.user.id }, { clan: clan._id }, { upsert: true, new: true });
+      if (!clan.members.includes(user._id)) {
+        clan.members.push(user._id);
+        await clan.save();
+      }
+      return interaction.reply(`Joined clan ${name}.`);
+    }
+
+    if (sub === 'leave') {
+      const user = await User.findOne({ userId: interaction.user.id });
+      if (!user || !user.clan) return interaction.reply({ content: 'You are not in a clan.', ephemeral: true });
+      const clan = await Clan.findById(user.clan);
+      clan.members = clan.members.filter(m => m.toString() !== user._id.toString());
+      await clan.save();
+      user.clan = null;
+      await user.save();
+      return interaction.reply('Left the clan.');
+    }
+
+    if (sub === 'info') {
+      const name = interaction.options.getString('name');
+      const clan = await Clan.findOne({ name }).populate('members');
+      if (!clan) return interaction.reply({ content: 'Clan not found.', ephemeral: true });
+      const embed = {
+        title: `Clan ${clan.name}`,
+        fields: [
+          { name: 'Elo', value: clan.elo.toString(), inline: true },
+          { name: 'Members', value: clan.members.length.toString(), inline: true }
+        ]
+      };
+      return interaction.reply({ embeds: [embed] });
+    }
+  }
+};

--- a/commands/economy/balance.js
+++ b/commands/economy/balance.js
@@ -1,0 +1,13 @@
+const { SlashCommandBuilder } = require('discord.js');
+const User = require('../../src/models/User');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('balance')
+    .setDescription('Show your money balance'),
+  async execute(interaction) {
+    let user = await User.findOne({ userId: interaction.user.id });
+    if (!user) user = await User.create({ userId: interaction.user.id });
+    await interaction.reply(`You have ${user.money} coins.`);
+  }
+};

--- a/commands/matchmaking/fight.js
+++ b/commands/matchmaking/fight.js
@@ -1,0 +1,30 @@
+const { SlashCommandBuilder } = require('discord.js');
+const User = require('../../src/models/User');
+
+const queue = [];
+
+async function startFight(p1, p2) {
+  p1.channel.send(`Fight between <@${p1.id}> and <@${p2.id}> starting!`);
+  const winner = Math.random() > 0.5 ? p1 : p2;
+  const loser = winner === p1 ? p2 : p1;
+
+  const winnerData = await User.findOneAndUpdate({ userId: winner.id }, { $inc: { wins: 1, elo: 10, money: 50 } }, { upsert: true, new: true });
+  const loserData = await User.findOneAndUpdate({ userId: loser.id }, { $inc: { losses: 1, elo: -10, money: -20 } }, { upsert: true, new: true });
+
+  winner.channel.send(`You won against ${loser.username}!`);
+  loser.channel.send(`You lost against ${winner.username}!`);
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('fight')
+    .setDescription('Enter matchmaking queue'),
+  async execute(interaction) {
+    queue.push(interaction.user);
+    await interaction.reply('You have been added to the queue.');
+    if (queue.length >= 2) {
+      const [p1, p2] = queue.splice(0, 2);
+      startFight(p1, p2);
+    }
+  }
+};

--- a/commands/premium/premium.js
+++ b/commands/premium/premium.js
@@ -1,0 +1,19 @@
+const { SlashCommandBuilder } = require('discord.js');
+const User = require('../../src/models/User');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('premium')
+    .setDescription('Manage premium status')
+    .addSubcommand(sc => sc.setName('add').setDescription('Grant premium')
+      .addUserOption(o => o.setName('user').setDescription('User').setRequired(true)))
+    .addSubcommand(sc => sc.setName('remove').setDescription('Remove premium')
+      .addUserOption(o => o.setName('user').setDescription('User').setRequired(true))),
+  async execute(interaction) {
+    if (interaction.user.id !== '648619791107620887') return interaction.reply({ content: 'Unauthorized', ephemeral: true });
+    const sub = interaction.options.getSubcommand();
+    const userOption = interaction.options.getUser('user');
+    const user = await User.findOneAndUpdate({ userId: userOption.id }, { premium: sub === 'add' }, { upsert: true, new: true });
+    return interaction.reply(`${sub === 'add' ? 'Granted' : 'Removed'} premium for ${userOption.username}.`);
+  }
+};

--- a/commands/profile/profile.js
+++ b/commands/profile/profile.js
@@ -1,0 +1,26 @@
+const { SlashCommandBuilder } = require('discord.js');
+const User = require('../../src/models/User');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('profile')
+    .setDescription('Show your MMA profile'),
+  async execute(interaction) {
+    let user = await User.findOne({ userId: interaction.user.id });
+    if (!user) {
+      user = await User.create({ userId: interaction.user.id });
+    }
+
+    const embed = {
+      title: `${interaction.user.username}'s Profile`,
+      fields: [
+        { name: 'Elo', value: user.elo.toString(), inline: true },
+        { name: 'Wins', value: user.wins.toString(), inline: true },
+        { name: 'Losses', value: user.losses.toString(), inline: true },
+        { name: 'Money', value: user.money.toString(), inline: true }
+      ]
+    };
+
+    await interaction.reply({ embeds: [embed] });
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,48 @@
+const { Client, IntentsBitField, Collection } = require('discord.js');
+const fs = require('fs');
+const path = require('path');
+const mongoose = require('mongoose');
+require('dotenv').config();
+
+const client = new Client({
+  intents: [IntentsBitField.Flags.Guilds]
+});
+
+client.commands = new Collection();
+
+const commandFolders = fs.readdirSync(path.join(__dirname, 'commands'));
+for (const folder of commandFolders) {
+  const commandFiles = fs.readdirSync(path.join(__dirname, 'commands', folder)).filter(file => file.endsWith('.js'));
+  for (const file of commandFiles) {
+    const command = require(`./commands/${folder}/${file}`);
+    client.commands.set(command.data.name, command);
+  }
+}
+
+client.once('ready', () => {
+  console.log(`Logged in as ${client.user.tag}`);
+});
+
+client.on('interactionCreate', async interaction => {
+  if (!interaction.isChatInputCommand()) return;
+
+  const command = client.commands.get(interaction.commandName);
+  if (!command) return;
+
+  try {
+    await command.execute(interaction);
+  } catch (error) {
+    console.error(error);
+    if (interaction.replied || interaction.deferred) {
+      await interaction.followUp({ content: 'There was an error executing that command.', ephemeral: true });
+    } else {
+      await interaction.reply({ content: 'There was an error executing that command.', ephemeral: true });
+    }
+  }
+});
+
+mongoose.connect(process.env.MONGO_URI || '', { useNewUrlParser: true, useUnifiedTopology: true })
+  .then(() => console.log('Connected to MongoDB'))
+  .catch(err => console.error('MongoDB connection error:', err));
+
+client.login(process.env.BOT_TOKEN);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mmabotdiscord",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/models/Clan.js
+++ b/src/models/Clan.js
@@ -1,0 +1,9 @@
+const { Schema, model } = require('mongoose');
+
+const clanSchema = new Schema({
+  name: { type: String, required: true, unique: true },
+  elo: { type: Number, default: 0 },
+  members: [{ type: Schema.Types.ObjectId, ref: 'User' }]
+});
+
+module.exports = model('Clan', clanSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,0 +1,13 @@
+const { Schema, model } = require('mongoose');
+
+const userSchema = new Schema({
+  userId: { type: String, required: true, unique: true },
+  elo: { type: Number, default: 1000 },
+  wins: { type: Number, default: 0 },
+  losses: { type: Number, default: 0 },
+  money: { type: Number, default: 0 },
+  clan: { type: Schema.Types.ObjectId, ref: 'Clan', default: null },
+  premium: { type: Boolean, default: false }
+});
+
+module.exports = model('User', userSchema);


### PR DESCRIPTION
## Summary
- setup Node.js project
- add Discord.js bot skeleton with MongoDB models
- implement basic commands: profile, clan management, premium/admin controls, fight queue, and balance
- provide example environment file and usage instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68867b971b448326bfab1595946dc3d1