### PR TITLE
Implement basic AI fight system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # MMA Discord Bot
 
-This project is an inter-server MMA combat bot for Discord, built with **discord.js** and **MongoDB**.
+This project is an inter-server MMA combat bot for Discord built with **discord.js** and **MongoDB**.
 
 ## Features
 
-- Matchmaking with `/fight`
-- User profiles with Elo and statistics using `/profile`
+- Matchmaking with `/fight` including an option to duel an AI
+- Turn based combat with HP and mana management
+- User profiles with leagues, Elo and statistics using `/profile`
 - Clan system with `/clan`
 - Economy commands like `/balance`
 - Premium and admin commands
@@ -25,4 +26,4 @@ This project is an inter-server MMA combat bot for Discord, built with **discord
 
 ## Notes
 
-The project contains basic implementations as a starting point and does not cover the entire specification. Further development is required to implement full combat mechanics and matchmaking logic.
+The bot implements a simplified combat engine. Additional features such as advanced matchmaking or consumables can be added from this base.

--- a/commands/matchmaking/fight.js
+++ b/commands/matchmaking/fight.js
@@ -1,30 +1,43 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { startFight } = require('../../src/fightEngine');
 const User = require('../../src/models/User');
 
 const queue = [];
 
-async function startFight(p1, p2) {
-  p1.channel.send(`Fight between <@${p1.id}> and <@${p2.id}> starting!`);
-  const winner = Math.random() > 0.5 ? p1 : p2;
-  const loser = winner === p1 ? p2 : p1;
-
-  const winnerData = await User.findOneAndUpdate({ userId: winner.id }, { $inc: { wins: 1, elo: 10, money: 50 } }, { upsert: true, new: true });
-  const loserData = await User.findOneAndUpdate({ userId: loser.id }, { $inc: { losses: 1, elo: -10, money: -20 } }, { upsert: true, new: true });
-
-  winner.channel.send(`You won against ${loser.username}!`);
-  loser.channel.send(`You lost against ${winner.username}!`);
+async function processQueue(channel) {
+  if (queue.length >= 2) {
+    const p1 = queue.shift();
+    const p2 = queue.shift();
+    const winnerId = await startFight(p1.user, p2.user, channel);
+    if (winnerId !== p1.user.id && winnerId !== p2.user.id) return;
+    const loserId = winnerId === p1.user.id ? p2.user.id : p1.user.id;
+    await User.findOneAndUpdate({ userId: winnerId }, { $inc: { wins: 1, elo: 10, money: 50 } }, { upsert: true });
+    await User.findOneAndUpdate({ userId: loserId }, { $inc: { losses: 1, elo: -10, money: -20 } }, { upsert: true });
+  }
 }
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('fight')
-    .setDescription('Enter matchmaking queue'),
+    .setDescription('Entrer dans la file d\'attente pour combattre'),
   async execute(interaction) {
-    queue.push(interaction.user);
-    await interaction.reply('You have been added to the queue.');
-    if (queue.length >= 2) {
-      const [p1, p2] = queue.splice(0, 2);
-      startFight(p1, p2);
-    }
+    queue.push({ user: interaction.user });
+    const row = new ActionRowBuilder().addComponents(
+      new ButtonBuilder().setCustomId('fight_ai').setLabel('Jouer contre une IA').setStyle(ButtonStyle.Primary)
+    );
+    const reply = await interaction.reply({ content: 'Ajout\u00e9 \u00e0 la file d\'attente.', components: [row], ephemeral: true, fetchReply: true });
+
+    const collector = reply.createMessageComponentCollector({ filter: i => i.customId === 'fight_ai' && i.user.id === interaction.user.id, time: 15000 });
+    collector.on('collect', async i => {
+      const idx = queue.findIndex(q => q.user.id === interaction.user.id);
+      if (idx !== -1) queue.splice(idx, 1);
+      await i.update({ content: 'D\u00e9but du combat contre l\'IA...', components: [] });
+      await startFight(interaction.user, { id: 'ai', username: 'IA' }, interaction.channel, { p2AI: true });
+      collector.stop();
+    });
+
+    collector.on('end', () => reply.edit({ components: [] }).catch(() => {}));
+
+    await processQueue(interaction.channel);
   }
 };

--- a/commands/profile/profile.js
+++ b/commands/profile/profile.js
@@ -1,23 +1,31 @@
 const { SlashCommandBuilder } = require('discord.js');
 const User = require('../../src/models/User');
+const Clan = require('../../src/models/Clan');
+
+function getLeague(elo) {
+  if (elo < 800) return '🥉 Bronze';
+  if (elo < 1200) return '🥈 Silver';
+  return '🥇 Gold';
+}
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('profile')
-    .setDescription('Show your MMA profile'),
+    .setDescription('Afficher ton profil MMA'),
   async execute(interaction) {
-    let user = await User.findOne({ userId: interaction.user.id });
-    if (!user) {
-      user = await User.create({ userId: interaction.user.id });
-    }
+    let user = await User.findOne({ userId: interaction.user.id }).populate('clan');
+    if (!user) user = await User.create({ userId: interaction.user.id });
 
     const embed = {
-      title: `${interaction.user.username}'s Profile`,
+      title: `Profil de ${interaction.user.username}`,
       fields: [
-        { name: 'Elo', value: user.elo.toString(), inline: true },
-        { name: 'Wins', value: user.wins.toString(), inline: true },
-        { name: 'Losses', value: user.losses.toString(), inline: true },
-        { name: 'Money', value: user.money.toString(), inline: true }
+        { name: 'Ligue', value: getLeague(user.elo), inline: true },
+        { name: 'Elo', value: String(user.elo), inline: true },
+        { name: 'Victoires', value: String(user.wins), inline: true },
+        { name: 'Défaites', value: String(user.losses), inline: true },
+        { name: 'Argent', value: String(user.money), inline: true },
+        { name: 'Clan', value: user.clan ? user.clan.name : 'Aucun', inline: true },
+        { name: 'Premium', value: user.premium ? 'Oui' : 'Non', inline: true }
       ]
     };
 

--- a/package.json
+++ b/package.json
@@ -9,5 +9,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "discord.js": "^14.11.0",
+    "mongoose": "^7.5.0"
+  }
 }

--- a/src/fightEngine.js
+++ b/src/fightEngine.js
@@ -1,0 +1,84 @@
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+const ACTIONS = {
+  quick: { cost: 5, success: 0.7, dmg: 5, label: 'Attaque rapide (-5 mana)' },
+  power: { cost: 10, success: 0.5, dmg: 10, label: 'Attaque puissante (-10 mana)' },
+  dodge: { cost: 5, success: 0.6, dmg: 0, label: 'Esquive (-5 mana)' },
+  mana: { cost: 0, success: 1, dmg: 0, label: 'Récupérer mana (+10 mana)' }
+};
+
+function randomAction() {
+  const keys = Object.keys(ACTIONS);
+  return keys[Math.floor(Math.random() * keys.length)];
+}
+
+async function askAction(player, channel) {
+  if (player.isAI) return randomAction();
+
+  const row = new ActionRowBuilder().addComponents(
+    new ButtonBuilder().setCustomId('quick').setLabel(ACTIONS.quick.label).setStyle(ButtonStyle.Primary),
+    new ButtonBuilder().setCustomId('power').setLabel(ACTIONS.power.label).setStyle(ButtonStyle.Danger),
+    new ButtonBuilder().setCustomId('dodge').setLabel(ACTIONS.dodge.label).setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder().setCustomId('mana').setLabel(ACTIONS.mana.label).setStyle(ButtonStyle.Success)
+  );
+
+  const msg = await channel.send({ content: `<@${player.user.id}>, choisis une action :`, components: [row] });
+  try {
+    const interaction = await msg.awaitMessageComponent({ filter: i => i.user.id === player.user.id, time: 10000 });
+    await interaction.deferUpdate();
+    await msg.edit({ components: [] });
+    return interaction.customId;
+  } catch (err) {
+    await msg.edit({ content: `Temps écoulé pour ${player.user.username}, récupération de mana par défaut.`, components: [] });
+    return 'mana';
+  }
+}
+
+function applyAction(action, actor, opponent) {
+  const data = ACTIONS[action];
+  if (actor.mana < data.cost) {
+    return `${actor.user ? actor.user.username : 'IA'} n'a pas assez de mana pour ${action}.`;
+  }
+  actor.mana -= data.cost;
+  if (action === 'mana') {
+    actor.mana = Math.min(actor.mana + 10, 30);
+    return `${actor.user ? actor.user.username : 'IA'} récupère 10 mana.`;
+  }
+  if (action === 'dodge') {
+    actor.dodging = Math.random() < data.success;
+    return actor.dodging ? `${actor.user.username} se prépare à esquiver.` : `${actor.user.username} rate son esquive.`;
+  }
+  if (Math.random() < data.success) {
+    if (!opponent.dodging) {
+      opponent.hp -= data.dmg;
+      return `${actor.user ? actor.user.username : 'IA'} touche et inflige ${data.dmg} dégâts.`;
+    }
+    return `${opponent.user.username} esquive l'attaque !`;
+  }
+  return `${actor.user ? actor.user.username : 'IA'} rate son attaque.`;
+}
+
+async function startFight(p1User, p2User, channel, options = {}) {
+  const p1 = { user: p1User, hp: 30, mana: 30, dodging: false, isAI: !!options.p1AI };
+  const p2 = { user: p2User, hp: 30, mana: 30, dodging: false, isAI: !!options.p2AI };
+
+  await channel.send(`Début du combat entre <@${p1.user.id}> et <@${p2.user.id}> !`);
+
+  let attacker = p1;
+  let defender = p2;
+
+  while (p1.hp > 0 && p2.hp > 0) {
+    attacker.dodging = false;
+    const action = await askAction(attacker, channel);
+    const result = applyAction(action, attacker, defender);
+    await channel.send(result + ` (HP ${p1.user.username}: ${p1.hp}, HP ${p2.user.username}: ${p2.hp})`);
+    if (defender.hp <= 0) break;
+    [attacker, defender] = [defender, attacker];
+  }
+
+  const winner = p1.hp > 0 ? p1 : p2;
+  await channel.send(`Victoire de <@${winner.user.id}> !`);
+  return winner.user.id;
+}
+
+module.exports = { startFight };


### PR DESCRIPTION
## Summary
- add an initial fight engine with turn-based actions
- upgrade `/fight` to use queue and fight engine with AI option
- enhance `/profile` output with league and clan info
- document new features
- declare `discord.js` and `mongoose` dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6886846cf8a483268ca450338775ca10